### PR TITLE
build: remove filehash dependency

### DIFF
--- a/res/requirements.txt
+++ b/res/requirements.txt
@@ -1,6 +1,5 @@
 PySide6
 shiboken6
-filehash
 openpyxl
 pandas==2.2.*
 pillow


### PR DESCRIPTION
You use it only a little bit. Can be easily replaced by stdlib methods.